### PR TITLE
:green_book: Typo in README: Broken Twitter Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For bugs and feature requests, [please create an issue](https://github.com/azu/t
 ## Author
 
 - [github/azu](https://github.com/azu)
-- [twitter/azu_re]http://twitter.com/azu_re)
+- [twitter/azu_re](http://twitter.com/azu_re)
 
 ## License
 


### PR DESCRIPTION
**Before:**

[twitter/azu_re]http://twitter.com/azu_re)

``` markdown
[twitter/azu_re]http://twitter.com/azu_re)
```

**After:**

[twitter/azu_re](http://twitter.com/azu_re)

``` markdown
[twitter/azu_re](http://twitter.com/azu_re)
```

See also https://github.com/azu/textlint-rule-no-exclamation-question-mark/commit/bf2b069dc5316034d24d5a7e8d1b078d5e9e1541#commitcomment-17350226.
